### PR TITLE
Created Dockerfile to run Respector.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,28 @@
+FROM ubuntu:20.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Installs dependencies from source/README.md
+RUN apt-get update && apt-get install -y openjdk-11-jdk openjdk-8-jdk maven gradle git python3 python3-pip
+
+# Installs pre-built z3
+RUN git clone https://github.com/Z3Prover/z3.git && \
+    cd z3 && \
+    git checkout 23c53c6820b2d0c786dc416dab9a50473a7bbde3 && \
+    python3 scripts/mk_make.py --java && \
+    cd build && \
+    make && \
+    make install
+
+# Set Z3_HOME env variable
+ENV Z3_HOME=/z3
+
+# Copies repo into container
+COPY . /Respector-morans-minions
+
+WORKDIR /Respector-morans-minions/source
+
+# Compiles Respector
+RUN mvn package
+
+WORKDIR /Respector-morans-minions

--- a/README.md
+++ b/README.md
@@ -40,6 +40,20 @@ You can either load our VM image to use the artifact directly, or set it up loca
 
 Please follow the instructions in `/source/README.md` for installing Respector locally on your host machine.
 
+### Use the Dockerfile
+
+To setup the enviroment in Docker, follow these steps:
+
+1. Open terminal in the directory of the Dockerfile.
+2. Run the following command to build the image. This will also compile Respector inside the image and may take some time (~15 min) to complete.
+    ```bash
+    docker build -t {environment-name} .
+    ```
+3. Run the Docker container with the following command:
+    ```bash
+    docker run -it {environment-name}
+    ```
+
 ### Use the VM
 
 Note: The virtual machine was created and tested using VirtualBox version 6.1 on Ubuntu 20.04. Make sure you have atleast 40 GB of free storage to download and execute the virtual machine.

--- a/source/pom.xml
+++ b/source/pom.xml
@@ -48,7 +48,7 @@
       <artifactId>z3</artifactId>
       <version>4.12.0.0</version>
       <scope>system</scope>
-      <systemPath>${basedir}/lib/com.microsoft.z3.jar</systemPath>
+      <systemPath>${env.Z3_HOME}/build/com.microsoft.z3.jar</systemPath>
     </dependency> 
 
     <dependency>


### PR DESCRIPTION
Dockerfile was created to compile and run Respector. Uses ubuntu:20.04 environment and checkouts same z3 version as one listed in instructions.

README updated with instructions on how to build and run Docker image.

Resolves #7 